### PR TITLE
Add dbsync to Aodh deployment

### DIFF
--- a/aodh/server.sls
+++ b/aodh/server.sls
@@ -1,7 +1,7 @@
 {%- from "aodh/map.jinja" import server with context %}
 {%- if server.enabled %}
 # Exclude unsupported openstack versions
-{%- if server.version >= "mitaka"  %}
+{%- if server.version not in ['liberty', 'juno', 'kilo'] %}
 
 server_packages:
   pkg.installed:

--- a/aodh/server.sls
+++ b/aodh/server.sls
@@ -14,6 +14,13 @@ server_packages:
   - require:
     - pkg: server_packages
 
+aodh_syncdb:
+  cmd.run:
+  - name: aodh-dbsync
+  - require:
+    - file: /etc/aodh/aodh.conf
+    - pkg: server_packages
+
 aodh_server_services:
   service.running:
   - names: {{ server.services }}


### PR DESCRIPTION
Because, Aodh works with mysql storage driver it needs dbsync during deployment